### PR TITLE
Export factory function to avoid explicit class construction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules
 # Files created by build scripts
 test-es5
 lib
+
+# PhpStorm
+.idea

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The approach taken by Enumify is heavily inspired by Java enums.
 
 Install:
 
-```text
-npm install enumify
+```sh
+npm install --save enumify2
 ```
 
 Use:
@@ -34,7 +34,7 @@ new Color();
 Or (without explicit class construction):
 
 ```js
-import {initEnum} from 'enumify';
+import {initEnum} from 'enumify2';
 const Color = initEnum(['RED', 'GREEN', 'BLUE']);
 // etc...
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Enumify
+# enumify2
 
 A JavaScript library for enums. To be used by transpiled ES6 (e.g. via Babel).
 
 The approach taken by Enumify is heavily inspired by Java enums.
+
+## Difference to enumify?
+
+`enumify2` adds the `initEnum` export that allows you to avoid explicit class construction and reduces the overhead of creating an enum.
 
 ## The basics
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ new Color();
     // Error: Enum classes can’t be instantiated
 ```
 
+Or (without explicit class construction):
+
+```js
+import {initEnum} from 'enumify';
+const Color = initEnum(['RED', 'GREEN', 'BLUE']);
+// etc...
+```
+
 ## Properties of enum classes
 
 Enums get a static property `enumValues`, which contains an Array with all enum values:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install --save enumify2
 Use:
 
 ```js
-import {Enum} from 'enumify';
+import {Enum} from 'enumify2';
 
 class Color extends Enum {}
 Color.initEnum(['RED', 'GREEN', 'BLUE']);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "enumify",
-  "version": "1.0.3",
+  "name": "enumify2",
+  "version": "1.0.0",
   "main": "./lib/enumify.js",
   "//": "babel-register is needed for mocha",
   "devDependencies": {
@@ -26,6 +26,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rauschma/enumify"
+    "url": "https://github.com/sdgluck/enumify2"
   }
 }

--- a/src/enumify.js
+++ b/src/enumify.js
@@ -9,7 +9,7 @@ export class Enum {
     /**
      * `initEnum()` closes the class. Then calling this constructor
      * throws an exception.
-     * 
+     *
      * If your subclass has a constructor then you can control
      * what properties are added to `this` via the argument you
      * pass to `super()`. No arguments are fine, too.
@@ -26,7 +26,7 @@ export class Enum {
     }
     /**
      * Set up the enum, close the class.
-     * 
+     *
      * @param arg Either an object whose properties provide the names
      * and values (which must be mutable objects) of the enum constants.
      * Or an Array whose elements are used as the names of the enum constants
@@ -38,9 +38,9 @@ export class Enum {
             configurable: false,
             writable: false,
             enumerable: true,
-        });            
+        });
         if (Array.isArray(arg)) {
-            this._enumValuesFromArray(arg);            
+            this._enumValuesFromArray(arg);
         } else {
             this._enumValuesFromObject(arg);
         }
@@ -48,20 +48,20 @@ export class Enum {
         this[INITIALIZED] = true;
         return this;
     }
-    
+
     static _enumValuesFromArray(arr) {
         for (let key of arr) {
             this._pushEnumValue(new this(), key);
         }
     }
-    
+
     static _enumValuesFromObject(obj) {
         for (let key of Object.keys(obj)) {
             let value = new this(obj[key]);
             this._pushEnumValue(value, key);
         }
     }
-    
+
     static _pushEnumValue(enumValue, name) {
         enumValue.name = name;
         enumValue.ordinal = this.enumValues.length;
@@ -70,10 +70,10 @@ export class Enum {
             configurable: false,
             writable: false,
             enumerable: true,
-        });            
+        });
         this.enumValues.push(enumValue);
     }
-    
+
     /**
      * Given the name of an enum constant, return its value.
      */
@@ -87,7 +87,7 @@ export class Enum {
     static [Symbol.iterator]() {
         return this.enumValues[Symbol.iterator]();
     }
-    
+
     /**
      * Default `toString()` method for enum constant.
      */
@@ -103,4 +103,9 @@ export function copyProperties(target, source) {
         Object.defineProperty(target, key, desc);
     }
     return target;
+}
+
+export function initEnum(arg) {
+    const _enum = class extends Enum {};
+    return _enum.initEnum(arg);
 }

--- a/test/basic-tests.js
+++ b/test/basic-tests.js
@@ -2,10 +2,13 @@
 /* global suite */
 
 import * as assert from 'assert';
-import {Enum} from '../src/enumify';
+import {
+    Enum,
+    initEnum
+} from '../src/enumify';
 
 //-------------------------------------------------
-suite('Enum: simple');
+suite('Enum: simple (explicit class construction)');
 
 class Color extends Enum {}
 Color.initEnum(['RED', 'GREEN', 'BLUE']);
@@ -31,6 +34,15 @@ test('Class is closed (can’t be instantiated)', () => {
     assert.throws(() => {
         new Color();
     });
+});
+
+//-------------------------------------------------
+suite('Enum: simple (factory function)');
+
+const Body = initEnum(['HEAD', 'SHOULDERS', 'KNEES', 'TOES']);
+
+test('instanceof', () => {
+    assert.ok(Body.HEAD instanceof Body);
 });
 
 //-------------------------------------------------


### PR DESCRIPTION
Currently creating multiple enums can get quite ugly:

```
import {Enum} from 'enumify'

class Color extends Enum {}
Color.initEnum(['RED', 'GREEN', 'BLUE'])

class Body extends Enum {}
Body.initEnum(['HEAD', 'SHOULDERS', 'KNEES', 'TOES'])
```

The crux of this PR is to export a function `initEnum` that tucks away the class declaration, allowing this:

```
import {initEnum} from 'enumify'

const Color = initEnum(['RED', 'GREEN', 'BLUE'])
const Body = initEnum(['HEAD', 'SHOULDERS', 'KNEES', 'TOES'])
```

The function is appended to `enumify.js` and looks like:

```
export function initEnum(arg) {
    const _enum = class extends Enum {};
    return _enum.initEnum(arg);
}
```

P.S. Thanks for a great module :-)
